### PR TITLE
fixed two compile time errors and update gitignore to ignore some mis…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,20 +68,64 @@ generated/
 /Android/ThirdParty/
 /Android/libs/
 
+####### Cmake gitignore #######
+
 # CMake generated build files
 CMakeCache.txt
-CMakeFiles/
-CMakeScripts/
+CMakeFiles
+CMakeScripts
+Testing
 Makefile
 cmake_install.cmake
 install_manifest.txt
+compile_commands.json
 CPackConfig.cmake
 CPackSourceConfig.cmake
 CTestTestfile.cmake
+
+#######
+
 /Source/**/*.cmake
 !/Source/ThirdParty/SDL/cmake/*.cmake
 !/Source/ThirdParty/SDL/include/*cmake
 /Docs/**/*.cmake
+
+####### C++ gitignore #######
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+#######
 
 # Precompiled header files
 *.gch/
@@ -101,3 +145,14 @@ configure*
 *.bak
 Thumbs.db
 .directory
+
+### some misc cmake generated files.
+**/*.vcxproj
+**/*.tlog
+**/*.filters
+**/*.pdb
+**/*.exp
+**/*.sln
+**/*.cmake
+**/*.in
+.vs

--- a/Source/ThirdParty/SDL/src/video/windows/SDL_windowsvideo.h
+++ b/Source/ThirdParty/SDL/src/video/windows/SDL_windowsvideo.h
@@ -79,7 +79,7 @@ typedef struct _TOUCHINPUT {
 
 #endif /* WINVER < 0x0601 */
 
-#if WINVER < 0x0603
+#if WINVER <= _WIN32_WINNT_WIN10
 
 typedef enum MONITOR_DPI_TYPE {
     MDT_EFFECTIVE_DPI = 0,

--- a/Source/Urho3D/IO/Log.cpp
+++ b/Source/Urho3D/IO/Log.cpp
@@ -81,7 +81,7 @@ Log::~Log()
 
 void Log::Open(const String& fileName)
 {
-#if !defined(__ANDROID__) && !defined(IOS) && !defined(TVOS)) && !defined(UWP)
+#if !defined(__ANDROID__) && !defined(IOS) && !defined(TVOS) && !defined(UWP)
     if (fileName.Empty())
         return;
     if (logFile_ && logFile_->IsOpen())


### PR DESCRIPTION
This is discussed in the https://forums.xamarin.com/discussion/111397/urhosharp-with-proper-uwp-support-x64-release#latest 

I see this is off of master and not your recent branch. (Still trying to follow the git stuff as my background is in SVN) I'll check out your crs_ADD_UWP_Support branch.  This commit fixed a compile error in master branch.

I downloaded the master branch, built docs using doxygen, read the html/_building.html from them. In the Native build process section, I installed cmake and ran 'cmake .' at root which created the Urho3D.sln. However in VS2017, a clean and build gives 333 Errors and 481 Warnings.

The first error I found is in Urho3D-master\Source\ThirdParty\SDL\src\video\windows\SDL_windowsvideo.h file line 82. The MONITOR_DPI_TYPE is not defined in because WINVER < 0x0603 (_WIN32_WINNT_WIN8 == 0x0602 in sdkddkver.h) is false since WINVER == 0x0A00 (_WIN32_WINNT_WIN10).

Second error is in Urho3D-master\Source\Urho3D\IO\Log.cpp file. It has extra ")" on line 84.

After fixing those two errors, a clean build gives 0 Errors and 204 Warnings. I was able to run 01_HelloWorld and the other examples at Release Win32.


  