### PR TITLE
Fix compile errors on crs-Add_UWP_Support branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,17 @@ configure*
 *.bak
 Thumbs.db
 .directory
+
+.vs/*
+**/*.vcxproj
+**/*.filters
+**/*.sln
+**/*.tlog
+**/*.pdb
+**/*.obj
+**/*.exp
+**/*.lib
+**/*.pch
+
+CMakeDoxyfile.in
+CMakeDoxygenDefaults.cmake

--- a/Source/ThirdParty/SDL/include/SDL_config.h.cmake
+++ b/Source/ThirdParty/SDL/include/SDL_config.h.cmake
@@ -380,7 +380,7 @@
 /* Platform specific definitions */
 #if !defined(__WIN32__)
 #  if !defined(_STDINT_H_) && !defined(_STDINT_H) && !defined(HAVE_STDINT_H) && !defined(_HAVE_STDINT_H)
-if !defined(UWP) && (!defined(UWP_HOLO) || !defined(_WIN64))
+#if !defined(UWP) && (!defined(UWP_HOLO) || !defined(_WIN64))
 typedef unsigned int size_t;
 #endif
 typedef signed char int8_t;

--- a/Source/Urho3D/AngelScript/ResourceAPI.cpp
+++ b/Source/Urho3D/AngelScript/ResourceAPI.cpp
@@ -226,8 +226,9 @@ static void RegisterImage(asIScriptEngine* engine)
     engine->RegisterObjectMethod("Image", "void Clear(const Color&in)", asMETHOD(Image, Clear), asCALL_THISCALL);
     engine->RegisterObjectMethod("Image", "void ClearInt(uint)", asMETHOD(Image, ClearInt), asCALL_THISCALL);
     engine->RegisterObjectMethod("Image", "bool SaveBMP(const String&in) const", asMETHOD(Image, SaveBMP), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Image", "bool SavePNG(const String&in) const", asMETHOD(Image, SavePNG), asCALL_THISCALL);
-    engine->RegisterObjectMethod("Image", "bool SaveTGA(const String&in) const", asMETHOD(Image, SaveTGA), asCALL_THISCALL);
+	engine->RegisterObjectMethod("Image", "bool SavePNG(const String&in) const", asMETHOD(Image, SavePNG), asCALL_THISCALL);
+	engine->RegisterObjectMethod("Image", "unsigned char@+ SavePNGAsChar(int@+ len) const", asMETHOD(Image, SavePNGAsChar), asCALL_THISCALL);
+	engine->RegisterObjectMethod("Image", "bool SaveTGA(const String&in) const", asMETHOD(Image, SaveTGA), asCALL_THISCALL);
     engine->RegisterObjectMethod("Image", "bool SaveJPG(const String&in, int) const", asMETHOD(Image, SaveJPG), asCALL_THISCALL);
     engine->RegisterObjectMethod("Image", "bool SaveDDS(const String&in) const", asMETHOD(Image, SaveDDS), asCALL_THISCALL);
     engine->RegisterObjectMethod("Image", "bool SaveWEBP(const String&in, float compression = 0.0f) const", asMETHOD(Image, SaveWEBP), asCALL_THISCALL);

--- a/Source/Urho3D/Resource/Image.cpp
+++ b/Source/Urho3D/Resource/Image.cpp
@@ -1247,7 +1247,7 @@ bool Image::SaveBMP(const String& fileName) const
         return false;
 }
 
-unsigned char* Image::SavePNG(int *len) const
+unsigned char* Image::SavePNGAsChar(int *len) const
 {
     URHO3D_PROFILE(SaveImagePNG);
     if (IsCompressed())

--- a/Source/Urho3D/Resource/Image.h
+++ b/Source/Urho3D/Resource/Image.h
@@ -138,7 +138,7 @@ public:
     /// Save in PNG format. Return true if successful.
     bool SavePNG(const String& fileName) const;
     /// Save in PNG format. Return true if successful.
-    unsigned char* SavePNG(int* len) const; 
+    unsigned char* SavePNGAsChar(int* len) const; 
     /// Save in TGA format. Return true if successful.
     bool SaveTGA(const String& fileName) const;
     /// Save in JPG format with specified quality. Return true if successful.


### PR DESCRIPTION
Compile errors
  
1. missing pound sign on macro statement.  
2. SavePNG ambiguous.
3. gitignore for cmake and Visual studio generated files.